### PR TITLE
Inject type for new factory models

### DIFF
--- a/src/Lib/LaramieModel.php
+++ b/src/Lib/LaramieModel.php
@@ -71,7 +71,7 @@ class LaramieModel implements \JsonSerializable
         } elseif ($data !== null && is_object($data)) {
             $data = self::hydrate($data);
         } elseif ($isReturnEmptyModelIfNullData && $data === null) {
-            $data = self::hydrate((object) []);
+            $data = self::hydrate((object) ['type' => static::getJsonClass()]);
         } else {
             throw new Exception('LaramieModel received invalid data type to load');
         }


### PR DESCRIPTION
Previously, when there was a miss in grabbing an item by id and the json had a factory defined, the new item was missing an appropriate internal 'type'. This resulted in a bug where users without access to a model could still create _new_ items of that type.