### PR TITLE
Add way to get filtered version of the underlying query builder used by LaramieModels

### DIFF
--- a/src/Lib/LaramieModel.php
+++ b/src/Lib/LaramieModel.php
@@ -516,6 +516,11 @@ class LaramieModel implements \JsonSerializable
         return static::setOption('filterQuery', $isFilterQuery);
     }
 
+    public static function getFilteredQueryBuilder()
+    {
+        return static::getLaramieQueryBuilder('getFilteredQueryBuilder');
+    }
+
     public static function query()
     {
         return static::getLaramieQueryBuilder('query');

--- a/src/Lib/LaramieQueryBuilder.php
+++ b/src/Lib/LaramieQueryBuilder.php
@@ -67,6 +67,14 @@ class LaramieQueryBuilder
         return $this->setOption('filterQuery', $isFilterQuery);
     }
 
+    public function getFilteredQueryBuilder()
+    {
+        $model = $this->dataService->getModelByKey($this->callingClass::getJsonClass());
+        $query = $this->dataService->getBaseQuery($model);
+
+        return $this->dataService->augmentListQuery($query, $model, array_merge($this->searchOptions, ['sort' => null]), $this->queryCallback);
+    }
+
     public function setOption(string $optionName, $optionValue)
     {
         $this->searchOptions[$optionName] = $optionValue;


### PR DESCRIPTION
Note that by doing so, it separates the return type from the invoking model (so regular objects representing dbs row will be returned, not laramie models).