### PR TITLE
Allow routes to bypass the need for mfa

### DIFF
--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -73,7 +73,7 @@ class Authenticate
         }
 
         // Check to see if we need to present the user MFA screens:
-        $mfaRequired = !$request->get('skipMfa');
+        $mfaRequired = !$request->get('skipMfa')
             && $user
             && config('laramie.enable_mfa', false)
             && object_get($user, 'mfa.enabled')


### PR DESCRIPTION
This would likely be a middleware (that gets hit _before_ this one) doing something like `$request->merge(['skipMfa' => true]);`
