### PR TITLE
Add ability to inject user used by hooks

### DIFF
--- a/src/Lib/LaramieModel.php
+++ b/src/Lib/LaramieModel.php
@@ -36,7 +36,7 @@ class LaramieModel implements \JsonSerializable
     protected static $globalHidden = [];
 
     protected $tableFields = ['id' => 1, 'user_id' => 1, 'type' => 1, 'data' => 1, 'created_at' => 1, 'updated_at' => 1];
-    protected $excludeAttributesOnSave = ['jsonClass' => 1, 'tableFields' => 1, 'excludeAttributesOnSave' => 1];
+    protected $excludeAttributesOnSave = ['jsonClass' => 1, 'tableFields' => 1, 'excludeAttributesOnSave' => 1, 'hidden' => 1];
     protected $jsonClass = null;
     protected $hidden = [];
 
@@ -514,6 +514,11 @@ class LaramieModel implements \JsonSerializable
     public static function filterQuery(bool $isFilterQuery)
     {
         return static::setOption('filterQuery', $isFilterQuery);
+    }
+
+    public static function asUser(LaramieModel $user)
+    {
+        return static::setOption('user', $user);
     }
 
     public static function getFilteredQueryBuilder()


### PR DESCRIPTION
This also changes the visibility of LaramieQueryBuilder's `save` method, as it's not something that is really meant to be used outside of the context of LaramieModel->save() (e.g., it was available as LaramieModel::where(blah)->save(), which shouldn't really happen; the updates still _allow_ it, but the API doesn't broadcast it now).